### PR TITLE
Handle special characters in issue labels

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -16,14 +16,14 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Use yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/needs-more-info/IssueTemplateValidator.js
+++ b/needs-more-info/IssueTemplateValidator.js
@@ -8,12 +8,16 @@ class IssueTemplateValidator {
     this.requiredSections = requiredSections;
   }
 
+  _normalizeSection(section) {
+    return section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
   _sectionExists(section) {
     return this._getSectionPosition(section) !== -1;
   }
 
   _getSectionPosition(section) {
-    const regexp = new RegExp(`[#]+[ ]+${section}`);
+    const regexp = new RegExp(`[#]+[ ]+${this._normalizeSection(section)}`);
     return this.issueBody.search(regexp);
   }
 
@@ -21,7 +25,8 @@ class IssueTemplateValidator {
   _isSectionEmpty(section) {
     const sectionPosition = this._getSectionPosition(section);
     const sub = this.issueBody.substr(sectionPosition);
-    const sectionStartIndex = sub.search(new RegExp(`${section}`)) + section.length;
+    const sectionStartIndex =
+      sub.search(new RegExp(`${this._normalizeSection(section)}`)) + section.length;
     const nextSectionPos = sub.search(/\n[#]+/);
     const end = nextSectionPos === -1 ? undefined : nextSectionPos;
     const sectionContent = sub.substring(sectionStartIndex, end);

--- a/needs-more-info/IssueTemplateValidator.js
+++ b/needs-more-info/IssueTemplateValidator.js
@@ -8,6 +8,7 @@ class IssueTemplateValidator {
     this.requiredSections = requiredSections;
   }
 
+  // Uses regex from `escape` https://github.com/LvChengbin/escape/blob/master/src/regexp.js
   _normalizeSection(section) {
     return section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }

--- a/needs-more-info/IssueTemplateValidator.test.js
+++ b/needs-more-info/IssueTemplateValidator.test.js
@@ -63,6 +63,24 @@ describe('IssueTemplateValidator', () => {
 
       expect(issueTemplateValidator._sectionExists('Reproduction')).toBe(false);
     });
+
+    it('should correctly recognize section with special characters', () => {
+      const issueBody = `
+      ## A link to a [Gist](https://gist.github.com/) that reproduces the bug.
+    
+      No repro yet.
+      `;
+
+      const issueTemplateValidator = new IssueTemplateValidator(issueBody, [
+        'A link to a [Gist](https://gist.github.com/) that reproduces the bug.',
+      ]);
+
+      expect(
+        issueTemplateValidator._sectionExists(
+          'A link to a [Gist](https://gist.github.com/) that reproduces the bug.'
+        )
+      ).toBe(true);
+    });
   });
 
   describe('_isSectionEmpty', () => {

--- a/needs-more-info/IssueTemplateValidator.test.js
+++ b/needs-more-info/IssueTemplateValidator.test.js
@@ -159,6 +159,24 @@ describe('IssueTemplateValidator', () => {
 
       expect(issueTemplateValidator._isSectionEmpty('Reproduction')).toBe(true);
     });
+
+    it('should correctly handle special characters', () => {
+      const issueBody = `
+      ## A link to a [Gist](https://gist.github.com/) that reproduces the bug.
+    
+      No repro yet.
+      `;
+
+      const issueTemplateValidator = new IssueTemplateValidator(issueBody, [
+        'A link to a [Gist](https://gist.github.com/) that reproduces the bug.',
+      ]);
+
+      expect(
+        issueTemplateValidator._isSectionEmpty(
+          'A link to a [Gist](https://gist.github.com/) that reproduces the bug.'
+        )
+      ).toBe(false);
+    });
   });
 
   describe('validate', () => {


### PR DESCRIPTION
Currently bot looks for label with the following regex:

```js
new RegExp(`${section}`)
```

Unfortunately, if label contains special characters (for example link to `gist`), this regex will not work (example in [this PR](https://github.com/software-mansion/react-native-gesture-handler/pull/3546)).

This PR adds `_normalizeSection` function which adds escape characters where they are needed. 